### PR TITLE
Clarify/simplify several aspects of command writing/loading.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=['spritzle_cli', 'spritzle_cli.commands'],
     entry_points={
         'console_scripts': [
-            'spritzle = spritzle_cli.main:main'
+            'spritzle = spritzle_cli.main:cli'
         ]
     },
     install_requires=[

--- a/spritzle_cli/commands/add.py
+++ b/spritzle_cli/commands/add.py
@@ -14,11 +14,11 @@ import click
               help=('Tag to apply to the torrent. Can be specified multiple '
                     'times.'))
 @click.pass_obj
-def main(ctx, path, option, tag):
-    ctx.do_command(f, path, option, tag)
+def command(client, path, option, tag):
+    client.do_command(f, path, option, tag)
 
 
-async def f(ctx, path, option, tag):
+async def f(client, path, option, tag):
     args = dict([o.split('=') for o in option])
     data = {
         'args': json.dumps(args),
@@ -30,7 +30,7 @@ async def f(ctx, path, option, tag):
     else:
         data['url'] = path
 
-    async with ctx.session.post(ctx.url('torrent'), data=data) as resp:
+    async with client.session.post(client.url('torrent'), data=data) as resp:
         if resp.status != 201:
             click.echo(
                 f'Error adding torrent: {resp.status} {resp.reason}',

--- a/spritzle_cli/commands/auth.py
+++ b/spritzle_cli/commands/auth.py
@@ -8,21 +8,21 @@ import yaml
 @click.command('auth', short_help='Generate an authentication token.')
 @click.option('--password', required=True, prompt=True, hide_input=True)
 @click.pass_obj
-def main(ctx, password):
-    ctx.do_command(f, password)
+def command(client, password):
+    client.do_command(f, password)
 
 
-async def f(ctx, password):
+async def f(client, password):
     data = {
         'password': password,
     }
-    async with ctx.session.post(ctx.url('auth'), data=data) as resp:
+    async with client.session.post(client.url('auth'), data=data) as resp:
         if resp.status != 200:
             click.echo(f'Error: {resp}', file=sys.stderr)
             sys.exit(1)
 
         d = await resp.json()
-        tf = Path(ctx.config, 'tokens')
+        tf = Path(client.config, 'tokens')
 
         if tf.exists():
             t = yaml.safe_load(tf.open(mode='r')) or {}
@@ -30,7 +30,7 @@ async def f(ctx, password):
             t = {}
 
         with tf.open(mode='w') as f:
-            t[f'{ctx.host}:{ctx.port}'] = d['token']
+            t[f'{client.host}:{client.port}'] = d['token']
             yaml.safe_dump(t, f, default_flow_style=False)
 
-        click.echo(f'Token for {ctx.host}:{ctx.port} updated.')
+        click.echo(f'Token for {client.host}:{client.port} updated.')

--- a/spritzle_cli/commands/list.py
+++ b/spritzle_cli/commands/list.py
@@ -12,17 +12,17 @@ from tabulate import tabulate
 @click.option('--header/--no-header', default=True,
               help='Print header in output.')
 @click.pass_obj
-def main(ctx, fields, header):
-    ctx.do_command(f, fields, header)
+def command(client, fields, header):
+    client.do_command(f, fields, header)
 
 
-async def f(ctx, fields, header):
+async def f(client, fields, header):
     type_formatters = {
         list: list_formatter,
     }
 
     fields = fields.split(',')
-    async with ctx.session.get(ctx.url('torrent')) as resp:
+    async with client.session.get(client.url('torrent')) as resp:
         if resp.status != 200:
             click.echo(f'Error: {resp}', file=sys.stderr)
             sys.exit(1)
@@ -30,7 +30,7 @@ async def f(ctx, fields, header):
 
     table = []
     for torrent in torrents:
-        async with ctx.session.get(ctx.url(f'torrent/{torrent}')) as resp:
+        async with client.session.get(client.url(f'torrent/{torrent}')) as resp:
             t = await resp.json()
             values = []
             for field in fields:

--- a/spritzle_cli/commands/remove.py
+++ b/spritzle_cli/commands/remove.py
@@ -8,16 +8,16 @@ import click
 @click.option('--delete-files', default=False, is_flag=True,
               help='Delete downloaded files.')
 @click.pass_obj
-def main(ctx, info_hash, delete_files):
-    ctx.do_command(f, info_hash, delete_files)
+def command(client, info_hash, delete_files):
+    client.do_command(f, info_hash, delete_files)
 
 
-async def f(ctx, info_hash, delete_files):
-    url = ctx.url(f'torrent/{info_hash}')
+async def f(client, info_hash, delete_files):
+    url = client.url(f'torrent/{info_hash}')
     if delete_files:
         url += '?delete_files'
 
-    async with ctx.session.delete(url) as resp:
+    async with client.session.delete(url) as resp:
         if resp.status != 200:
             click.echo(
                 f'Error removing torrent: {resp.status} {resp.reason}',

--- a/spritzle_cli/commands/settings.py
+++ b/spritzle_cli/commands/settings.py
@@ -10,23 +10,23 @@ from tabulate import tabulate
 @click.option('--set', '-s', 'set_value', type=str, nargs=2, multiple=True,
               help='Set a property value as: key value')
 @click.pass_obj
-def main(ctx, set_value):
+def command(client, set_value):
     if set_value:
-        ctx.do_command(setter, set_value)
+        client.do_command(setter, set_value)
     else:
-        ctx.do_command(show)
+        client.do_command(show)
 
 
-async def setter(ctx, set_value):
+async def setter(client, set_value):
     data = json.dumps(dict(set_value))
-    async with ctx.session.put(ctx.url('settings'), data=data) as resp:
+    async with client.session.put(client.url('settings'), data=data) as resp:
         if resp.status != 200:
             click.echo(f'Error: {resp}', file=sys.stderr)
             sys.exit(1)
 
 
-async def show(ctx):
-    async with ctx.session.get(ctx.url('settings')) as resp:
+async def show(client):
+    async with client.session.get(client.url('settings')) as resp:
         if resp.status != 200:
             click.echo(f'Error: {resp}', file=sys.stderr)
             sys.exit(1)

--- a/spritzle_cli/commands/status.py
+++ b/spritzle_cli/commands/status.py
@@ -6,12 +6,12 @@ from tabulate import tabulate
 
 @click.command('status', short_help='Show status of the session.')
 @click.pass_obj
-def main(ctx):
-    ctx.do_command(f)
+def command(client):
+    client.do_command(f)
 
 
-async def f(ctx):
-    async with ctx.session.get(ctx.url('session')) as resp:
+async def f(client):
+    async with client.session.get(client.url('session')) as resp:
         if resp.status != 200:
             click.echo(f'Error: {resp}', file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
This PR does a few things that I think simplify/clarify the code:
- The individual commands were using `click.pass_obj` decorator, yet calling the passed in object `ctx`. I renamed the class to `Client` and the variable passed in to commands `client`.
- I think the custom `Main` class for the main click command was unneeded. That was changed to a regular `click.group`, and a a separate function added to load the commands. (This also means individual commands could skip the `name` parameter to `click.command` and the module name will now be used instead. I didn't remove the explicit naming though.)
- Changed the command loader to use `pkgutil`, rather than the filtered listdir to load the command files.
- Changed the command file directory location to use `pathlib` rather than `os.path` functions.
- Changed the main entry function to be called `cli` rather than `main`
- Changed the entry point in individual commands to be called `command` rather than `main`.

Happy to discuss/revert any of these changes, but I think they overall make things a bit clearer.